### PR TITLE
Make autotick bot try to update dependencies

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,6 +7,7 @@ conda_build:
 conda_forge_output_validation: true
 bot:
   automerge: true
+  inspection: update-grayskull
 build_platform:
   osx_arm64: osx_64
   linux_aarch64: linux_64

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 7f37753b7eb5123745714a935ffba8e5472ffb234f4bd86db46d48599c623143
 
 build:
-  number: 1
+  number: 2
   skip: not (match(python, python_min) and is_abi3)
   python:
     version_independent: true


### PR DESCRIPTION
In order to avoid inconsistencies like #16

- [x] Merge #16
- [x] Update build number in this PR